### PR TITLE
Fix Uncaught TypeError: date.getDay is not a function in @d3fc/d3fc-d…

### DIFF
--- a/packages/victory-voronoi-container/src/voronoi-helpers.js
+++ b/packages/victory-voronoi-container/src/voronoi-helpers.js
@@ -42,7 +42,7 @@ const VoronoiHelpers = {
       const style = child ? child.props && child.props.style : props.style;
       return data.map((datum, index) => {
         const { x, y, y0, x0 } = Helpers.getPoint(datum);
-        const voronoiX = (Number(x) + Number(x0)) / 2;
+        const voronoiX = new Date((Number(x) + Number(x0)) / 2);
         const voronoiY = (Number(y) + Number(y0)) / 2;
 
         return assign(


### PR DESCRIPTION
Fix Uncaught TypeError: date.getDay is not a function in @d3fc/d3fc-discontinuous-scale/**/skipWeekends.js

When combine `VictoryVoronoiContainer` with 
```
scaleDiscontinuous(
    d3Scale.scaleTime()
  ).discontinuityProvider(discontinuitySkipWeekends())
```

there would be an error: **TypeError: date.getDay is not a function** when hovering the Chart